### PR TITLE
Remove base origins using origins, not layer

### DIFF
--- a/src/main/resources/data/origins/origin_layers/origin.json
+++ b/src/main/resources/data/origins/origin_layers/origin.json
@@ -1,26 +1,20 @@
 {
-  "replace": true,
-  "loading_priority": 1,
-  "order": 0,
-  "enabled": true,
+  "replace": false,
   "origins": [
-    "origins:human",
-    "maddy_origins:construct",
     "maddy_origins:critter",
-    "maddy_origins:avian",
-    "maddy_origins:undead",
-    "maddy_origins:cured",
     "maddy_origins:slimefolk",
-    "maddy_origins:netherdweller",
+    "maddy_origins:amphibian",
+    "maddy_origins:avian",
     "maddy_origins:insect",
     "maddy_origins:outcast",
-    "maddy_origins:amphibian"
+    "maddy_origins:construct",
+    "maddy_origins:undead",
+    "maddy_origins:netherdweller",
+    "maddy_origins:cured"
   ],
   "allow_random": true,
   "exclude_random": [
     "origins:human",
     "maddy_origins:cured"
-  ],
-  "allow_random_unchoosable": false,
-  "hidden": false
-} 
+  ]
+}

--- a/src/main/resources/data/origins/origins/arachnid.json
+++ b/src/main/resources/data/origins/origins/arachnid.json
@@ -1,0 +1,4 @@
+{
+	"loading_priority": 100,
+	"unchoosable": true
+}

--- a/src/main/resources/data/origins/origins/avian.json
+++ b/src/main/resources/data/origins/origins/avian.json
@@ -1,0 +1,4 @@
+{
+	"loading_priority": 100,
+	"unchoosable": true
+}

--- a/src/main/resources/data/origins/origins/blazeborn.json
+++ b/src/main/resources/data/origins/origins/blazeborn.json
@@ -1,0 +1,4 @@
+{
+	"loading_priority": 100,
+	"unchoosable": true
+}

--- a/src/main/resources/data/origins/origins/elytrian.json
+++ b/src/main/resources/data/origins/origins/elytrian.json
@@ -1,0 +1,4 @@
+{
+	"loading_priority": 100,
+	"unchoosable": true
+}

--- a/src/main/resources/data/origins/origins/enderian.json
+++ b/src/main/resources/data/origins/origins/enderian.json
@@ -1,0 +1,4 @@
+{
+	"loading_priority": 100,
+	"unchoosable": true
+}

--- a/src/main/resources/data/origins/origins/feline.json
+++ b/src/main/resources/data/origins/origins/feline.json
@@ -1,0 +1,4 @@
+{
+	"loading_priority": 100,
+	"unchoosable": true
+}

--- a/src/main/resources/data/origins/origins/merling.json
+++ b/src/main/resources/data/origins/origins/merling.json
@@ -1,0 +1,4 @@
+{
+	"loading_priority": 100,
+	"unchoosable": true
+}

--- a/src/main/resources/data/origins/origins/phantom.json
+++ b/src/main/resources/data/origins/origins/phantom.json
@@ -1,0 +1,4 @@
+{
+	"loading_priority": 100,
+	"unchoosable": true
+}

--- a/src/main/resources/data/origins/origins/shulk.json
+++ b/src/main/resources/data/origins/origins/shulk.json
@@ -1,0 +1,4 @@
+{
+	"loading_priority": 100,
+	"unchoosable": true
+}


### PR DESCRIPTION
Still prevents the builtin origins from being chosen, but doesn't require a `replace: true` layer, which isn't compatible with other mods adding origins.